### PR TITLE
Build Webrio via Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build shared library
         run: |
           cd libsm64
-          make lib -j`nproc`
+          emmake make CC=emcc
 
       - name: Build Webrio
         run: make webrio.js -e LIB_SM_PATH=./libsm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: Build Webrio
+
+on: [push, pull_request]
+
+jobs:
+  Build:
+    name: Build Webrio for ${{ matrix.identifier }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: emscripten
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Checkout libsm64
+        uses: actions/checkout@v4
+        with:
+            repository: 'libsm64/libsm64'
+            path: ~/aux/libsm64
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+
+      #- name: Set up MinGW
+      #  uses: egor-tensin/setup-mingw@v2
+
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
+          sudo apt-get update -y -qq
+          sudo apt-get install libsdl2-dev libglew-dev
+
+      - name: Build Webrio
+        run: make webrio.js
+
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: Webrio_Demo
+          path: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
             repository: 'libsm64/libsm64'
-            path: ./libsm64
+            path: ../libsm64
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -30,22 +30,19 @@ jobs:
       - name: Set up Emscripten
         uses: mymindstorm/setup-emsdk@v14
 
-      #- name: Set up MinGW
-      #  uses: egor-tensin/setup-mingw@v2
-
       - name: Install dependencies
         run: |
           sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
           sudo apt-get update -y -qq
           sudo apt-get install libsdl2-dev libglew-dev
 
-      - name: Build shared library
+      - name: Build libsm64
         run: |
           cd libsm64
           emmake make CC=emcc
 
       - name: Build Webrio
-        run: make webrio.js -e LIB_SM_PATH=./libsm64
+        run: make webrio.js -e LIB_SM_PATH=../libsm64
 
       - name: Upload build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,11 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get install libsdl2-dev libglew-dev
 
+      - name: Build shared library
+        run: |
+          cd libsm64
+          make lib -j`nproc`
+
       - name: Build Webrio
         run: make webrio.js -e LIB_SM_PATH=./libsm64
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
             repository: 'libsm64/libsm64'
-            path: ../libsm64
+            path: ./libsm64
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -38,11 +38,11 @@ jobs:
 
       - name: Build libsm64
         run: |
-          cd ../libsm64
+          cd ./libsm64
           emmake make CC=emcc
 
       - name: Build Webrio
-        run: make webrio.js -e LIB_SM_PATH=../libsm64
+        run: make webrio.js -e LIB_SM_PATH=./libsm64
 
       - name: Upload build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
             repository: 'libsm64/libsm64'
-            path: ~/aux/libsm64
+            path: ./libsm64
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -40,7 +40,7 @@ jobs:
           sudo apt-get install libsdl2-dev libglew-dev
 
       - name: Build Webrio
-        run: make webrio.js
+        run: make webrio.js -e LIB_SM_PATH=./libsm64
 
       - name: Upload build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build libsm64
         run: |
-          cd libsm64
+          cd ../libsm64
           emmake make CC=emcc
 
       - name: Build Webrio

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 LIB_SM_PATH = ~/aux/libsm64 # defaults
 
-libsm64/dist/libsm64.so: emcc $(LIB_SM_PATH)/dist/libsm64.so -o $(LIB_SM_PATH)/dist/libsm64.js -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_RUNTIME_METHODS=ccall,cwrap -s EXPORTED_FUNCTIONS=_malloc,_free -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=1 -s DEMANGLE_SUPPORT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s EXPORT_NAME=SM64Module
+#libsm64/dist/libsm64.so: 
+#	emcc $(LIB_SM_PATH)/dist/libsm64.so -o $(LIB_SM_PATH)/dist/libsm64.js -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_RUNTIME_METHODS=ccall,cwrap -s EXPORTED_FUNCTIONS=_malloc,_free -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=1 -s DEMANGLE_SUPPORT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s EXPORT_NAME=SM64Module
 
 webrio.js: webrio.c level.c $(LIB_SM_PATH)/dist/libsm64.so
 	emcc -sEXPORTED_FUNCTIONS=_webrio_init,_webrio_tick,_webrio_get_sm64_texture_width,_webrio_get_sm64_texture_height,_malloc,_webrio_get_surfaces_count,_webrio_get_surface_type,_webrio_get_surface_force,_webrio_get_surface_terrain,_webrio_get_surface_vertices \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 LIB_SM_PATH = ~/aux/libsm64 # defaults
 
-#libsm64/dist/libsm64.so: 
-#	emcc $(LIB_SM_PATH)/dist/libsm64.so -o $(LIB_SM_PATH)/dist/libsm64.js -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_RUNTIME_METHODS=ccall,cwrap -s EXPORTED_FUNCTIONS=_malloc,_free -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=1 -s DEMANGLE_SUPPORT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s EXPORT_NAME=SM64Module
-
 webrio.js: webrio.c level.c $(LIB_SM_PATH)/dist/libsm64.so
 	emcc -sEXPORTED_FUNCTIONS=_webrio_init,_webrio_tick,_webrio_get_sm64_texture_width,_webrio_get_sm64_texture_height,_malloc,_webrio_get_surfaces_count,_webrio_get_surface_type,_webrio_get_surface_force,_webrio_get_surface_terrain,_webrio_get_surface_vertices \
 	  	-sEXPORTED_RUNTIME_METHODS=ccall,cwrap \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-webrio.js: webrio.c level.c ~/aux/libsm64/dist/libsm64.so
+LIB_SM_PATH = ~/aux/libsm64 # defaults
+
+webrio.js: webrio.c level.c $(LIB_SM_PATH)/dist/libsm64.so
 	emcc -sEXPORTED_FUNCTIONS=_webrio_init,_webrio_tick,_webrio_get_sm64_texture_width,_webrio_get_sm64_texture_height,_malloc,_webrio_get_surfaces_count,_webrio_get_surface_type,_webrio_get_surface_force,_webrio_get_surface_terrain,_webrio_get_surface_vertices \
 	  	-sEXPORTED_RUNTIME_METHODS=ccall,cwrap \
 		-sEXPORT_ES6=1 -sMODULARIZE -sEXPORT_NAME=webrio \
-		-I ~/aux/libsm64/src -o $@ $^
+		-I $(LIB_SM_PATH)/src -o $@ $^
 
 clean:
 	rm webrio.js webrio.wasm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 LIB_SM_PATH = ~/aux/libsm64 # defaults
 
+libsm64/dist/libsm64.so: emcc $(LIB_SM_PATH)/dist/libsm64.so -o $(LIB_SM_PATH)/dist/libsm64.js -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_RUNTIME_METHODS=ccall,cwrap -s EXPORTED_FUNCTIONS=_malloc,_free -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=1 -s DEMANGLE_SUPPORT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s EXPORT_NAME=SM64Module
+
 webrio.js: webrio.c level.c $(LIB_SM_PATH)/dist/libsm64.so
 	emcc -sEXPORTED_FUNCTIONS=_webrio_init,_webrio_tick,_webrio_get_sm64_texture_width,_webrio_get_sm64_texture_height,_malloc,_webrio_get_surfaces_count,_webrio_get_surface_type,_webrio_get_surface_force,_webrio_get_surface_terrain,_webrio_get_surface_vertices \
 	  	-sEXPORTED_RUNTIME_METHODS=ccall,cwrap \


### PR DESCRIPTION
I'm beginning to think about this again; after meandering in the "direct-from-javascript" wasteland, I think your method of C-Bindings to WASM is the most efficient, so this PR just helps me replicate your results without getting Emscripten set up locally 😅 

I've incorporated this version of Webrio into this sample webapp using three.js:
https://zalo.github.io/libsm64-three/
https://github.com/zalo/libsm64-three/

I added vertex interpolation so that it feels smoother on high refresh-rate monitors 😎 

This seems like a solid foundation for adding new features 😄